### PR TITLE
resourcenfresser 

### DIFF
--- a/main.c
+++ b/main.c
@@ -13,10 +13,15 @@ enum { ZOOM = 14 };
 static unsigned char display[DISPLAY_HEIGHT][DISPLAY_WIDTH];
 static int button_state[8];
 
+int rerender = 0;
+
 void pixel(int x, int y, unsigned char color) {
 	assert(x < DISPLAY_WIDTH);
 	assert(y < DISPLAY_HEIGHT);
 	assert(color < 16);
+	
+	if( display[y][x] != color)	rerender = 1;
+	
 	display[y][x] = color;
 }
 
@@ -118,14 +123,19 @@ int main(int argc, char *argv[]) {
 
 		tetris_update();
 
-		for(int x = 0; x < DISPLAY_WIDTH; x++)
-			for(int y = 0; y < DISPLAY_HEIGHT; y++)
-				Draw_FillCircle(screen, ZOOM*x + ZOOM/2, ZOOM*y + ZOOM/2, ZOOM*0.45, COLORS[display[y][x]]);
+		if(rerender)
+		{
+			rerender=0;
+			for(int x = 0; x < DISPLAY_WIDTH; x++)
+				for(int y = 0; y < DISPLAY_HEIGHT; y++)
+					Draw_FillCircle(screen, ZOOM*x + ZOOM/2, ZOOM*y + ZOOM/2, ZOOM*0.45, COLORS[display[y][x]]);
 
-		SDL_Flip(screen);
+			SDL_Flip(screen);
+		}
+		
 		SDL_Delay(20);
 	}
-
+	
 	SDL_Quit();
 	return 0;
 }

--- a/tetris.c
+++ b/tetris.c
@@ -17,7 +17,7 @@ void tetris_load() {
 	int i;
 	for(i = 0; i < MAX_PLAYERS; i++) init_grid(&grids[i]);
 	
-	player_count = 3;
+	player_count = 6;
 }
 
 void tetris_update() {


### PR DESCRIPTION
hab das mal so gemacht, das er nur rendert, wenn auch mind. ein pixel sich verändert hat. 

Das spart extrem viel ein. Für den ARM würd ich aber gerne noch weiter optimieren, schließlich kommt ja noch einiges dazu was auch noch CPU kostet.

die ganze draw_grid funktion kann sich ebenfalls so ein ditry flag setzten, so das auch sie nur den display buffer nur dann befüllt, wenn sich auch was getan hat. 

Ich werd auf dem ARM die CPU load messen können, ich hätte neben dem Tetris gern noch 30% CPU frei, damit der funkcode genug hat und auch die SD karte geschrieben werden kann und noch bissel anderer kleinkram.
