### PR TITLE
Inform client about game state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tetris
 libs/text.o
+*.kdev4

--- a/grid.c
+++ b/grid.c
@@ -213,8 +213,8 @@ static void get_grid_input(Grid* grid, int* mov, int* rot, int* drop) {
 
 
 
-static void update_grid_normal(Grid* grid) {
-	int i, x, y;
+static int update_grid_normal(Grid* grid) {
+	int i, x, y, change = 0;
 
 	int mov, rot, drop;
 	get_grid_input(grid, &mov, &rot, &drop);
@@ -232,6 +232,7 @@ static void update_grid_normal(Grid* grid) {
 	// horizontal movement
 	i = grid->x;
 	grid->x += mov;
+	if (mov) change = 1;
 	if(i != grid->x && grid_collision(grid, 0)) grid->x = i;
 
 
@@ -240,6 +241,7 @@ static void update_grid_normal(Grid* grid) {
 	if(drop || grid->tick >= grid->ticks_per_drop) {
 		grid->tick = 0;
 		grid->y++;
+		change = 1;
 		if(grid_collision(grid, 0)) {
 			grid->y--;
 
@@ -253,7 +255,7 @@ static void update_grid_normal(Grid* grid) {
 
 			stone_to_grid(grid, grid->stone + 1);
 
-			if(over) return;
+			if(over) return 1;
 
 
 			// get a new stone
@@ -273,6 +275,7 @@ static void update_grid_normal(Grid* grid) {
 			grid->state_delay = 0;
 		}
 	}
+	return change;
 }
 
 
@@ -413,29 +416,28 @@ int activate_grid(Grid* grid) {
 }
 
 
-void update_grid(Grid* grid) {
+int update_grid(Grid* grid) {
 	switch(grid->state) {
 	case STATE_FREE:
 		update_grid_free(grid);
-		break;
+		return 0;
 
 	case STATE_NORMAL:
-		update_grid_normal(grid);
-		break;
+		return update_grid_normal(grid);
 
 	case STATE_WAIT:
 		update_grid_wait(grid);
-		break;
+		return 0;
 
 	case STATE_CLEARLINES:
 		update_grid_clearlines(grid);
-		break;
+		return 0;
 
 	case STATE_GAMEOVER:
 		update_grid_gameover(grid);
-		break;
+		return 0;
 
-	default: break;
+	default: return 0;
 
 	}
 }

--- a/grid.c
+++ b/grid.c
@@ -405,6 +405,7 @@ void init_grid(Grid* grid, int nr) {
 			pixel(grid->nr * 12 + x, y, 0);
 		}
 	}
+	++grid->game_id;
 }
 
 int activate_grid(Grid* grid) {

--- a/grid.c
+++ b/grid.c
@@ -259,6 +259,10 @@ static int update_grid_normal(Grid* grid) {
 
 
 			// get a new stone
+			grid->last_x = grid->x;
+			grid->last_y = grid->y;
+			grid->last_stone = grid->stone;
+			grid->last_rot = grid->rot;
 			new_stone(grid);
 
 			// check for complete lines

--- a/grid.h
+++ b/grid.h
@@ -35,6 +35,7 @@ typedef struct Grid {
 	int input_mov;
 	int input_rep;
 	int input_rot;
+	char game_id; // game-over detection for KIs
 } Grid;
 
 void init_grid(Grid* grid, int nr);

--- a/grid.h
+++ b/grid.h
@@ -39,7 +39,7 @@ typedef struct Grid {
 
 void init_grid(Grid* grid, int nr);
 int activate_grid(Grid* grid);
-void update_grid(Grid* grid);
+int update_grid(Grid* grid); // return: 1 if something changed
 void draw_grid(Grid* grid);
 
 #endif

--- a/grid.h
+++ b/grid.h
@@ -35,7 +35,9 @@ typedef struct Grid {
 	int input_mov;
 	int input_rep;
 	int input_rot;
-	char game_id; // game-over detection for KIs
+	char game_id; // game-over detection for KIs (the value is unpredictable, but will only be re-used after 256 games)
+	// information about the last stone that was fixed (for KIs). only reliable if stone_count > 0
+	int last_x, last_y, last_stone, last_rot;
 } Grid;
 
 void init_grid(Grid* grid, int nr);

--- a/r0ketr1s_sdl/config.h
+++ b/r0ketr1s_sdl/config.h
@@ -5,7 +5,7 @@ enum {
 };
 
 const unsigned char announce_addr[5] = { 'R', 'E', 'M', '0', 'T' };
-const unsigned char game_addr[5] = { 0x55, 0xC3, 0xD2, 0x28, 0xC3 };
+const unsigned char game_receive_addr[5] = { 0x55, 0xC3, 0xD2, 0x28, 0xC3 };
 const unsigned char game_id[2] = { 0xC3, 0xD2 };
 
 enum { ZOOM = 14 };

--- a/r0ketr1s_sdl/config.h
+++ b/r0ketr1s_sdl/config.h
@@ -4,7 +4,7 @@ enum {
 	GAME_CHANNEL		= 83,
 };
 
-const unsigned char announce_addr[5] = { 'R', 'E', 'M', '0', 'T' };
+const unsigned char announce_addr[5] = { 'R', 'E', 'B', '0', 'T' };
 const unsigned char game_receive_addr[5] = { 0x55, 0xC3, 0xD2, 0x28, 0xC3 };
 const unsigned char game_id[2] = { 0xC3, 0xD2 };
 

--- a/r0ketr1s_sdl/main.c
+++ b/r0ketr1s_sdl/main.c
@@ -282,7 +282,7 @@ sendtext(int nr) {
 		text_packet.text.y=15;
 		text_packet.text.flags=0;
 	
-		sprintf((char*)text_packet.text.text, "Lines %i", players[nr].lines);
+		sprintf((char*)text_packet.text.text, "Lines %i   ", players[nr].lines);
 	}
 	
 	send_packet(&text_packet);
@@ -590,7 +590,6 @@ int main(int argc, char *argv[]) {
 			// check whether anybody wants to join
 			for(i = 0; i < MAX_JOINER; i++) {
 				if(joiners[i].occupied) {
-// 					state = STATE_JOIN_ACK_SEND;
 					joiners[i].occupied = 0;
 					cmd_block = 1;
 					join(i);
@@ -602,7 +601,6 @@ int main(int argc, char *argv[]) {
 			// check whether anybody should get text
 			for(i = 0; i < MAX_PLAYER; i++) {
 				if(players[i].ready_to_send && wants_to_send_data(&players[i])) {
-// 					state = STATE_DATA_SEND;
 					cmd_block = 1;
 					if (players[i].needs_text || players[i].needs_lines)
 						sendtext(i);
@@ -615,37 +613,6 @@ int main(int argc, char *argv[]) {
 			if(i != MAX_PLAYER) break;
 
 			break;
-
-
-		// join stuff
-		/*case STATE_JOIN_ACK_SEND:
-			for(i = 0; i < MAX_JOINER; i++) {
-				if(joiners[i].occupied) {
-					joiners[i].occupied = 0;
-					cmd_block = 1;
-					join(i);
-					break;
-				}
-			}
-			assert(i < MAX_JOINER);
-			state = STATE_IDLE;
-			break;*/
-
-		// data send
-		/*case STATE_DATA_SEND:
-			for(i = 0; i < MAX_PLAYER; i++) {
-				if(players[i].ready_to_send && wants_to_send_data(&players[i])) {
-					cmd_block = 1;
-					if (players[i].needs_text || players[i].needs_lines)
-						sendtext(i);
-					else
-						sendstate(i);
-					players[i].ready_to_send = 0;
-					break;
-				}
-			}
-			state = STATE_IDLE;
-			break;*/
 
 
 		// announce stuff

--- a/r0ketr1s_sdl/main.c
+++ b/r0ketr1s_sdl/main.c
@@ -295,6 +295,11 @@ void sendstate(int nr) {
 
 	blob_packet.blob.data[0]=grids[nr].x;
 	blob_packet.blob.data[1]=grids[nr].y;
+	blob_packet.blob.data[2]=grids[nr].stone;
+	blob_packet.blob.data[3]=grids[nr].rot;
+	blob_packet.blob.data[4]=grids[nr].stone_count;
+	blob_packet.blob.data[5]=grids[nr].game_id;
+	
 	
 	send_packet(&blob_packet);
 }

--- a/r0ketr1s_sdl/main.c
+++ b/r0ketr1s_sdl/main.c
@@ -34,8 +34,8 @@ typedef struct {
 	int occupied;
 	int request_nick;
 	int is_ready_for_nick;
-	int needs_text;
-	int needs_lines;
+	int needs_text; // "Player <n>"
+	int needs_lines; // will never actually be set at the same time as needs_text (text is sent just once at the beginning)
 	int lines;
 	int is_ready_for_text;
 	int button_state;
@@ -55,11 +55,9 @@ enum {
 Joiner joiners[MAX_JOINER];
 Player players[MAX_PLAYER];
 
-
 void init_serial() {
 
-//	serial = open("/dev/ttyACM0", O_RDWR | O_NONBLOCK);
-	serial = open("/dev/cu.usbmodem5d11", O_RDWR | O_NONBLOCK);
+	serial = open("/dev/ttyACM0", O_RDWR | O_NONBLOCK);
 	assert(serial != -1);
 
 	struct termios config;
@@ -97,26 +95,24 @@ void push_lines(unsigned int nr, unsigned int lines) {
 
 void send_cmd(int cmd, const unsigned char* buffer, int len) {
 
-	printf("send cmd %c len %d\n", cmd, len);
+	//printf("send cmd %c len %d\n", cmd, len);
 
 	static unsigned char magic[4] = { CMD_ESC, 0, CMD_ESC, CMD_END };
 
 	magic[1] = cmd;
-//	tcdrain(serial);
 	assert(write(serial, magic, 2) == 2);
+	usleep(500);
 	int i;
 	for(i = 0; i < len; i++) {
-//		tcdrain(serial);
 		assert(write(serial, &buffer[i], 1) == 1);
-		if(buffer[i] == 92) {
-//			tcdrain(serial);
+		usleep(500);
+		if(buffer[i] == CMD_ESC) {
 			assert(write(serial, &buffer[i], 1) == 1);
+			usleep(500);
 		}
 	}
-//	tcdrain(serial);
 	assert(write(serial, magic + 2, 2) == 2);
-//	tcdrain(serial);
-	
+	usleep(500);
 }
 
 void set_chan(unsigned char chan) {
@@ -147,11 +143,13 @@ void send_packet(Packet* p) {
 	p->crc[0] = (crc >> 8) & 0xff;
 	p->crc[1] = crc & 0xff;
 
+	
 	send_cmd(CMD_PACKET, (unsigned char*)p, sizeof(Packet));
+	printf("sent packet %c\n", p->command);
 }
 
 
-Packet announce_packet;
+static Packet announce_packet;
 void prepare_announce() {
 	memset(&announce_packet, 0, sizeof(Packet));
 	announce_packet.len = 32;
@@ -176,7 +174,7 @@ void announce() {
 }
 
 
-Packet ack_packet;
+static Packet ack_packet;
 void prepare_acknowledge() {
 	memset(&ack_packet, 0, sizeof(Packet));
 	ack_packet.len = 32;
@@ -184,7 +182,7 @@ void prepare_acknowledge() {
 	ack_packet.command = 'a';
 }
 
-Packet nickrequest_packet;
+static Packet nickrequest_packet;
 void prepare_nickrequest() {
 	memset(&nickrequest_packet, 0, sizeof(Packet));
 	nickrequest_packet.len = 32;
@@ -192,7 +190,7 @@ void prepare_nickrequest() {
 	nickrequest_packet.command = 'N';
 }
 
-Packet text_packet;
+static Packet text_packet;
 void prepare_text() {
 	memset(&text_packet, 0, sizeof(Packet));
 	text_packet.len = 32;
@@ -254,26 +252,26 @@ void
 sendtext(int nr) {
 	memcpy(text_packet.id, players[nr].id, 4);
 	unsigned char* c = (unsigned char*)&text_packet.counter;
-	if(++c[0] || ++c[1] || ++c[2] || ++c[3]) {}
+	if(++c[0] || ++c[1] || ++c[2] || ++c[3]) {} // increment counter
 
 
 	if(players[nr].needs_text)
 	{
 		text_packet.text.x=1;
 		text_packet.text.y=1;
-		text_packet.text.flags=1;
+		text_packet.text.flags=1; // clear screen before printing
 	
 		memcpy(text_packet.text.text, "Player ", 7);
 		text_packet.text.text[7] = 49 + nr;
 	}
-
-	if(players[nr].needs_lines)
+	
+	else if(players[nr].needs_lines)
 	{
 		text_packet.text.x=1;
 		text_packet.text.y=15;
 		text_packet.text.flags=0;
 	
-		sprintf(text_packet.text.text, "Lines %i", players[nr].lines);
+		sprintf((char*)text_packet.text.text, "Lines %i", players[nr].lines);
 	}
 	
 	send_packet(&text_packet);
@@ -322,7 +320,8 @@ void process_cmd(unsigned char cmd, Packet* packet, unsigned char len) {
 			case 'B':
 				for(i = 0; i < MAX_PLAYER; i++) {
 					if(!memcmp(players[i].id, packet->id, 4)) {
-						if((players[i].needs_text)||(players[i].needs_lines))   players[i].is_ready_for_text = 1;
+						if((players[i].needs_text)||(players[i].needs_lines))
+							players[i].is_ready_for_text = 1;
 						if(players[i].request_nick) players[i].is_ready_for_nick = 1;
 						players[i].last_active = get_time();
 						players[i].button_state = packet->button.state;
@@ -359,8 +358,10 @@ void process_cmd(unsigned char cmd, Packet* packet, unsigned char len) {
 			case 'a':
 				for(i = 0; i < MAX_PLAYER; i++) {
 					if(!memcmp(players[i].id, packet->id, 4)) {
-						players[i].needs_text = 0; 
-						players[i].needs_lines = 0; 
+						if (players[i].needs_text)
+							players[i].needs_text = 0; 
+						else
+							players[i].needs_lines = 0; 
 						break;
 					}
 				}
@@ -374,7 +375,7 @@ void process_cmd(unsigned char cmd, Packet* packet, unsigned char len) {
 		return;
 
 	default:
-		puts("what???");
+		printf("Unknown command 0x%02X\n", cmd);
 		return;
 	}
 }
@@ -468,7 +469,8 @@ int main(int argc, char *argv[]) {
 				continue;
 			}
 
-			if(esc) {
+			if (pos >= 254) pos = 0; // the next loop run could go out of our array... we get garbage anyway, so just keep reading garbage
+			if(esc) { // last byte was ESC
 				esc = 0;
 				if(byte == CMD_ESC) {
 					data[pos++] = CMD_ESC;
@@ -586,7 +588,9 @@ int main(int argc, char *argv[]) {
 
 			// check whether anybody should send get text
 			for(i = 0; i < MAX_PLAYER; i++) {
-				if((players[i].is_ready_for_text)&&((players[i].needs_text)||(players[i].needs_lines))&&(!players[i].request_nick)) {
+				if((players[i].is_ready_for_text)
+						&&((players[i].needs_text)||(players[i].needs_lines))
+						&&(!players[i].request_nick)) {
 					state = STATE_TEXT_TX_MAC;
 					break;
 				}
@@ -652,7 +656,7 @@ int main(int argc, char *argv[]) {
 				}
 			}
 			assert(i < MAX_PLAYER);
-			state = STATE_NICKREQUEST_RESTORE_TX_MAC;
+			state = STATE_TEXT_RESTORE_TX_MAC;
 			break;
 
 

--- a/r0ketr1s_sdl/main.c
+++ b/r0ketr1s_sdl/main.c
@@ -102,19 +102,20 @@ void send_cmd(int cmd, const unsigned char* buffer, int len) {
 	static unsigned char magic[4] = { CMD_ESC, 0, CMD_ESC, CMD_END };
 
 	magic[1] = cmd;
-	tcdrain(serial);
+//	tcdrain(serial);
 	assert(write(serial, magic, 2) == 2);
 	int i;
 	for(i = 0; i < len; i++) {
-		tcdrain(serial);
+//		tcdrain(serial);
 		assert(write(serial, &buffer[i], 1) == 1);
 		if(buffer[i] == 92) {
-			tcdrain(serial);
+//			tcdrain(serial);
 			assert(write(serial, &buffer[i], 1) == 1);
 		}
 	}
-	tcdrain(serial);
+//	tcdrain(serial);
 	assert(write(serial, magic + 2, 2) == 2);
+//	tcdrain(serial);
 	
 }
 

--- a/r0ketr1s_sdl/main.c
+++ b/r0ketr1s_sdl/main.c
@@ -53,6 +53,21 @@ enum {
 	MAX_PLAYER = 6,
 };
 
+enum {
+	DATA_X = 0,
+	DATA_Y,
+	DATA_STONE,
+	DATA_ROT,
+	DATA_STONE_ID,
+	DATA_GAME_ID,
+	DATA_LAST_X,
+	DATA_LAST_Y,
+	DATA_LAST_STONE,
+	DATA_LAST_ROT,
+	DATA_NEXT_STONE,
+	DATA_NEXT_ROT
+};
+
 Joiner joiners[MAX_JOINER];
 Player players[MAX_PLAYER];
 
@@ -293,12 +308,18 @@ void sendstate(int nr) {
 	unsigned char* c = (unsigned char*)&blob_packet.counter;
 	if(++c[0] || ++c[1] || ++c[2] || ++c[3]) {} // increment counter
 
-	blob_packet.blob.data[0]=grids[nr].x;
-	blob_packet.blob.data[1]=grids[nr].y;
-	blob_packet.blob.data[2]=grids[nr].stone;
-	blob_packet.blob.data[3]=grids[nr].rot;
-	blob_packet.blob.data[4]=grids[nr].stone_count;
-	blob_packet.blob.data[5]=grids[nr].game_id;
+	blob_packet.blob.data[DATA_X]=grids[nr].x;
+	blob_packet.blob.data[DATA_Y]=grids[nr].y;
+	blob_packet.blob.data[DATA_STONE]=grids[nr].stone;
+	blob_packet.blob.data[DATA_ROT]=grids[nr].rot;
+	blob_packet.blob.data[DATA_STONE_ID]=grids[nr].stone_count;
+	blob_packet.blob.data[DATA_GAME_ID]=grids[nr].game_id;
+	blob_packet.blob.data[DATA_LAST_X]=grids[nr].last_x;
+	blob_packet.blob.data[DATA_LAST_Y]=grids[nr].last_y;
+	blob_packet.blob.data[DATA_LAST_STONE]=grids[nr].last_stone;
+	blob_packet.blob.data[DATA_LAST_ROT]=grids[nr].last_rot;
+	blob_packet.blob.data[DATA_NEXT_STONE]=grids[nr].next_stone;
+	blob_packet.blob.data[DATA_NEXT_ROT]=grids[nr].next_rot;
 	
 	
 	send_packet(&blob_packet);

--- a/r0ketr1s_sdl/main.h
+++ b/r0ketr1s_sdl/main.h
@@ -98,9 +98,9 @@ enum {
 	STATE_ANNOUNCE_SET_MAC,
 	STATE_ANNOUNCE_SEND,
 	// join
-	STATE_JOIN_ACK_SEND,
+// 	STATE_JOIN_ACK_SEND,
 	// send some stuff
-	STATE_DATA_SEND,
+// 	STATE_DATA_SEND,
 };
 
 

--- a/r0ketr1s_sdl/main.h
+++ b/r0ketr1s_sdl/main.h
@@ -7,20 +7,20 @@
 
 enum {
 	CMD_ESC			= 92,
-	CMD_END			= 48,
-	CMD_PACKET		= 49,
-	CMD_OK			= 50,
-	CMD_TX_MAC		= 51,
-	CMD_RX_MAC		= 52,
-	CMD_CHAN		= 53,
-	CMD_PACKETLEN	= 54,
+	CMD_END			= 48,//  '0'
+	CMD_PACKET		= 49,//  '1'
+	CMD_OK			= 50,//  '2'
+	CMD_TX_MAC		= 51,//  '3'
+	CMD_RX_MAC		= 52,//  '4'
+	CMD_CHAN		= 53,//  '5'
+	CMD_PACKETLEN	= 54,//  '6'
 };
 
 typedef struct {
 	// 11 common bytes
 	unsigned char len;			// 32
 	unsigned char protocol;		// 'G'
-	unsigned char command;		// 'A'nounce 'J'oin 'a'ck 'B'utton ...
+	unsigned char command;		// 'A'nounce 'J'oin 'a'ck 'B'utton ... 'b'lob
 	unsigned char id[4];
 	unsigned char counter[4];	// network byte order
 
@@ -75,6 +75,10 @@ typedef struct {
 			unsigned char text[16];
 		} PACK text;
 
+		struct {
+			unsigned char data[19];
+		} PACK blob;
+
 	};
 
 	unsigned char crc[2];
@@ -82,23 +86,21 @@ typedef struct {
 } PACK Packet;
 
 enum {
+	// initialize
 	STATE_INIT_PACKETLEN,
 	STATE_INIT_RX_MAC,
-	STATE_INIT_TX_MAC,
-	STATE_INIT_CHAN,
+	// default state
+	STATE_RESTORE_CHAN, // game channel
+	STATE_RESTORE_MAC, // game mac
 	STATE_IDLE,
-	STATE_ANNOUNCE_CHAN,
-	STATE_ANNOUNCE_ANNOUNCE,
-	STATE_ANNOUNCE_RESTORE_CHAN,
-	STATE_JOIN_ACK_TX_MAC,
-	STATE_JOIN_ACK_ACK,
-	STATE_JOIN_ACK_RESTORE_TX_MAC,
-	STATE_NICKREQUEST_TX_MAC,
-	STATE_NICKREQUEST_NICKREQUEST,
-	STATE_NICKREQUEST_RESTORE_TX_MAC,
-	STATE_TEXT_TX_MAC,
-	STATE_TEXT_TEXT,
-	STATE_TEXT_RESTORE_TX_MAC,
+	// do ann announcement
+	STATE_ANNOUNCE_SET_CHAN,
+	STATE_ANNOUNCE_SET_MAC,
+	STATE_ANNOUNCE_SEND,
+	// join
+	STATE_JOIN_ACK_SEND,
+	// send some stuff
+	STATE_DATA_SEND,
 };
 
 


### PR DESCRIPTION
This patchset informs the client about the game state, so that - for example - a KI can be implemented on the r0ket. It uses a new kind of packet, 'b' (for blob or binary).
It should contain all the information necessary for a KI.

The state machine for the bridge communication is changed so that the channel and MAC most packets are sent on is set per default, to reduce the number of changes.

To avoid needlessly sending all that data to a client not needing it, maybe the join packet could be extended by a flag signalling whether the data is even desired?
